### PR TITLE
Explicitly use relative importing.

### DIFF
--- a/libexadt/EXAConf.py
+++ b/libexadt/EXAConf.py
@@ -1,5 +1,5 @@
 import sys, os, stat, ipaddr, configobj, StringIO, hashlib, re
-from utils import units2bytes, bytes2units, gen_base64_passwd, get_euid, get_egid, gen_node_uuid
+from .utils import units2bytes, bytes2units, gen_base64_passwd, get_euid, get_egid, gen_node_uuid
 from collections import OrderedDict as odict
 
 #{{{ Class EXAConfError

--- a/libexadt/device_handler.py
+++ b/libexadt/device_handler.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python2.7
 
 import os, glob
-import EXAConf
-from utils import bytes2units
+from . import EXAConf
+from .utils import bytes2units
 from collections import OrderedDict as odict
 
 #{{{ Class DeviceError

--- a/libexadt/docker_handler.py
+++ b/libexadt/docker_handler.py
@@ -1,6 +1,6 @@
-import os,docker,pprint,shutil,device_handler
+import os, docker, pprint, shutil
 from docker.utils import kwargs_from_env
-from . import EXAConf
+from . import device_handler, EXAConf
 from .utils import rotate_file
 from .EXAConf import config
 

--- a/libexadt/docker_handler.py
+++ b/libexadt/docker_handler.py
@@ -1,8 +1,8 @@
 import os,docker,pprint,shutil,device_handler
 from docker.utils import kwargs_from_env
-import EXAConf
-from utils import rotate_file
-from EXAConf import config
+from . import EXAConf
+from .utils import rotate_file
+from .EXAConf import config
 
 ip_types = { 4: 'ipv4_address', 6: 'ipv6_address' }
  

--- a/libexadt/docker_rpc_handler.py
+++ b/libexadt/docker_rpc_handler.py
@@ -1,4 +1,4 @@
-import rpc_handler, docker_handler
+from . import rpc_handler, docker_handler
 
 class docker_rpc_handler(rpc_handler.rpc_handler):
     """

--- a/libexadt/exadt_conf.py
+++ b/libexadt/exadt_conf.py
@@ -1,5 +1,5 @@
 import os, ConfigParser
-from EXAConf import config
+from .EXAConf import config
  
 #{{{ Class ConfError
 class ConfError(Exception):


### PR DESCRIPTION
This might elimitate rare cases, where a wrong library would be imported.